### PR TITLE
pointing to the sag docs that are retrieved by the jenkins job

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,8 +16,8 @@
 
 
   <!-- Fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Lato:300,400,300italic,400italic' rel='stylesheet' type='text/css'>
-  <link href='http://fonts.googleapis.com/css?family=Montserrat:400,700' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Lato:300,400,300italic,400italic' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Montserrat:400,700' rel='stylesheet' type='text/css'>
 
   <!-- Global CSS -->
 

--- a/documentation/4.3/bmg.adoc
+++ b/documentation/4.3/bmg.adoc
@@ -1,0 +1,16 @@
+---
+title: 4.3 Documentation 
+visible_title: "Big Memory Go PDF Documentation - 4.3"
+---
+
+
+[options="header"]
+|===
+|&nbsp;
+|link:/documentation/4.3/bigmemory-go-configuration-guide-4.3.3.pdf[Configuration Guide]
+|link:/documentation/4.3/bigmemory-go-installation-guide-4.3.3.pdf[Installation Guide]
+|link:/documentation/4.3/bigmemory-go-integrations-4.3.3.pdf[Integrations Guide]
+|link:/documentation/4.3/bigmemory-go-operations-guide-4.3.3.pdf[Operations Guide]
+|===
+
+

--- a/documentation/4.3/bmm.adoc
+++ b/documentation/4.3/bmm.adoc
@@ -1,0 +1,19 @@
+---
+title: 4.3 Documentation 
+visible_title: "Big Memory Max PDF Documentation - 4.3"
+---
+
+
+[options="header"]
+|===
+|&nbsp;
+|link:/documentation/4.3/bigmemory-max-administrator-guide-4.3.3.pdf[Administrator Guide]
+|link:/documentation/4.3/bigmemory-max-installation-guide-4.3.3.pdf[Installation Guide]
+|link:/documentation/4.3/bigmemory-max-configuration-guide-4.3.3.pdf[Configuration Guide]
+|link:/documentation/4.3/bigmemory-max-integrations-4.3.3.pdf[Integration Guide]
+|link:/documentation/4.3/bigmemory-max-security-guide-4.3.3.pdf[Security Guide]
+|link:/documentation/4.3/bigmemory-max-upgrade-and-migration-guide-4.3.3.pdf[Migration Guide]
+|link:/documentation/4.3/bigmemory-wan-replication-guide-4.3.3.pdf[Replication Guide]
+|===
+
+

--- a/documentation/4.3/ws.adoc
+++ b/documentation/4.3/ws.adoc
@@ -1,0 +1,13 @@
+---
+title: 4.3 Documentation 
+visible_title: "Web Sessions PDF Documentation - 4.3"
+---
+
+
+[options="header"]
+|===
+|&nbsp;
+|link:/documentation/4.3/web-sessions-user-guide-4.3.3.pdf[User Guide]
+|===
+
+

--- a/documentation/index.adoc
+++ b/documentation/index.adoc
@@ -10,23 +10,22 @@ permalink: /documentation/
 
 #### Current Documentation
 
-[cols="3,1", options="header"]
+[options="header"]
 |===
-|
-|
+|&nbsp;|&nbsp;|&nbsp;
+|BigMemory Max 4.3|link:/documentation/4.3/bmm-all/[HTML, window="_blank"]|link:/documentation/4.3/bmm[PDF]
+|BigMemory Go 4.3|link:/documentation/4.3/bmg-all/[HTML, window="_blank"]|link:/documentation/4.3/bmg[PDF]
+|Quartz Scheduler 2.2|link:/documentation/4.3/qs-all/[HTML, window="_blank"]|
+|Web Sessions 4.3|link:/documentation/4.3/ws-all/[HTML, window="_blank"]|link:/documentation/4.3/ws[PDF]
+|Universal Messaging|link:http://um.terracotta.org[HTML, window="_blank"]|
 
-|link:/documentation/4.3/[Terracotta 4.3 Documentation]
-|link:/apidocs/3.0.0/index.html[JavaDoc ??????, role="external", window="_blank"]
-
-|---
-| &nbsp;
-
-|link:http://www.terracotta.org/confluence/display/release/Home[Platform and Release Compatibility Tables, role="external", window="_blank"]
-|
-
-|link:/about/license.html[License] (Terracotta Public License, Apache 2.0),  link:/files/legal/TOE_3.0.pdf[3rd Party Licenses], link:http://documentation.softwareag.com/legal/[Legal Notices, role="external", window="_blank"]
-|
 |===
+
+
+link:http://www.terracotta.org/confluence/display/release/Home[Platform and Release Compatibility Tables, role="external", window="_blank"]
+
+
+link:/about/license.html[License] (Terracotta Public License, Apache 2.0),  link:/files/legal/TOE_3.0.pdf[3rd Party Licenses], link:http://documentation.softwareag.com/legal/[Legal Notices, role="external", window="_blank"]
 
 If you don’t find what you’re looking for in the docs, post a question to the https://groups.google.com/forum/#!forum/terracotta-oss[Terracotta support forums, role="external", window="_blank"].
 
@@ -42,11 +41,8 @@ https://confluence.terracotta.org//display/release/Home[Release Notes, role="ext
 
 #### Historical Versions
 
-[cols="3,1", options="header"]
+[options="header"]
 |===
-|
-|
-
-|link:/documentation/4.1/[Terracotta 4.1 Documentation]
-|link:/apidocs/2.9/index.html[JavaDoc ????, role="external", window="_blank"]
+|&nbsp;|&nbsp;
+|Terracotta 3.7 Documentation|link:3.7.4/Terracotta-Documentation-3.7.4.pdf[PDF, window="_blank"]
 |===


### PR DESCRIPTION
Note: although the site builds, the documentation is retrieved by the jenkins job and thus the documentation viewer will display broken links if the docs are not available locally.  Not putting that logic in the codebase as it deals with internal urls. This resolves #7  

PDF's are TBD